### PR TITLE
Update simple-import-sort to v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
 
         'prettier/prettier': 'warn',
 
-        'simple-import-sort/sort': [
+        'simple-import-sort/imports': [
             'warn',
             {
                 groups: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bytro",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "description": "Bytro Labs ESLint configuration",
   "main": "index.js",
   "repository": {
@@ -25,7 +25,7 @@
     "eslint-plugin-import": ">= 2",
     "eslint-plugin-jsdoc": ">= 30",
     "eslint-plugin-prettier": ">= 3",
-    "eslint-plugin-simple-import-sort": ">= 5",
+    "eslint-plugin-simple-import-sort": "6.*",
     "prettier": ">= 2"
   },
   "dependencies": {


### PR DESCRIPTION
Encountered issues like:
`error[simple-import-sort/sort]: Definition for rule 'simple-import-sort/sort' was not found`

They have renamed that rule in version 6 🙄
https://github.com/lydell/eslint-plugin-simple-import-sort/blob/v6.0.0/CHANGELOG.md#version-600-2020-11-15